### PR TITLE
Remove output format restriction for pdf

### DIFF
--- a/pandoc_styles/main.py
+++ b/pandoc_styles/main.py
@@ -209,7 +209,7 @@ class PandocStyles:
         if self.target:
             cfg[OUTPUT_FILE] = join(self.target, cfg[OUTPUT_FILE])
         cfg[FMT] = fmt
-        cfg[TO_FMT] = LATEX if fmt == PDF else fmt
+        cfg[TO_FMT] = fmt
         cfg[MD_TEMP_DIR] = self.temp_dir
         cfg[MD_CFG_DIR] = CONFIG_DIR
         cfg[MD_STYLE_PACKS] = self.used_stylepacks


### PR DESCRIPTION
The provided example works either way:

```yaml
---
title:  Example
author: John Doe
formats:
    - html
    - pdf
style-definition:
    all:
        toc: true
        toc-depth: 3
        highlight-style: tango
        language: en
    html:
        standalone: true
    pdf:
        pdf-engine: xelatex
---
```
As of pandoc version 3.1.8

Moreover, removing this restriction allows using other pdf engines, such as:

```yaml
        pdf-engine: mkhtmltopdf
```